### PR TITLE
Update Dockerfile - add new Bun release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:latest
 RUN apt update && apt -y install curl vim jq ldap-utils unzip p7zip python3-pip
 RUN curl -Lo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
 	curl -Lo /usr/local/bin/dcos https://downloads.dcos.io/cli/releases/binaries/dcos/linux/x86-64/1.1.0/dcos && \
-	curl -LO https://github.com/mesosphere/bun/releases/download/v2.2.0/bun_linux_amd64.tar.gz && \
+	curl -LO https://github.com/mesosphere/bun/releases/download/v2.3.2/bun_linux_amd64.tar.gz && \
 	tar xzf bun_linux_amd64.tar.gz && \
 	mv bun /usr/local/bin/ && \
 	curl -Lo /usr/local/bin/dcosjq https://raw.githubusercontent.com/some-things/dcosjq/master/dcosjq.sh && \


### PR DESCRIPTION
Patched Dockerfile to include the latest Bun release (v2.3.2)